### PR TITLE
strings should be symbols to match documentation

### DIFF
--- a/app/overrides/add_column_content.rb
+++ b/app/overrides/add_column_content.rb
@@ -1,5 +1,5 @@
 if SETTINGS[:column_view]
-  SETTINGS[:column_view].reject { |k,v| v[:view] && v[:view] != 'hosts_list' }.keys.sort.map do |k|
+  SETTINGS[:column_view].reject { |k,v| v[:view] && v[:view] != :hosts_list }.keys.sort.map do |k|
     after = SETTINGS[:column_view][k.to_sym][:after]
     Deface::Override.new(
       :virtual_path => "hosts/_list",

--- a/app/overrides/add_column_title.rb
+++ b/app/overrides/add_column_title.rb
@@ -1,5 +1,5 @@
 if SETTINGS[:column_view]
-  SETTINGS[:column_view].reject { |k,v| v[:view] && v[:view] != 'hosts_list' }.keys.sort.map do |k|
+  SETTINGS[:column_view].reject { |k,v| v[:view] && v[:view] != :hosts_list }.keys.sort.map do |k|
     after = SETTINGS[:column_view][k.to_sym][:after]
     Deface::Override.new(
       :virtual_path => "hosts/_list",


### PR DESCRIPTION
The documentation has the symbol :hosts_properties, so if we're using symbols in one location we should use them in all. 
