### PR TITLE
Relax deface dependency for 1.x compatibility

### DIFF
--- a/foreman_column_view.gemspec
+++ b/foreman_column_view.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.licenses = ["GPL-3"]
   s.summary = "Column View Plugin for Foreman"
 
-  s.add_dependency "deface", "< 1.0"
+  s.add_dependency "deface", "< 2.0"
 end
 


### PR DESCRIPTION
Untested, but doesn't appear to use any code/erb matchers in its overrides.