### PR TITLE
Update readme for config file location and params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ foreman_column_view.yaml. For package based installs this should be in
 ```
 
 `title` is an arbitrary string which is displayed as the column header. `content` is
-a method call to the `Host` object, using `host.send`. You can also access `Hash` or `Params` objects:
+a method call to the `Host` object, using `host.send`. In these examples `facts_hash`
+and `params` are method calls to `Host` returning hash values.
 
 ```yaml
 :column_view:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Update Foreman with the new gems:
 
 By default the plugin will display the Domain associated by each host. This is not
 massively useful. To set your own choice of column, add this to Foreman's plugin config file 
-foreman_column_view.yaml. For package based installs this should be in 
-/etc/foreman/plugins/foreman_column_view.yaml. For source installs the directory may differ.
+`foreman_column_view.yaml`. For package based installs this should be in 
+`/etc/foreman/plugins/foreman_column_view.yaml`. For source installs this should be in 
+`config/settings.plugins.d` within your install directory.
 
 ```yaml
 :column_view:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Update Foreman with the new gems:
 # Configuration
 
 By default the plugin will display the Domain associated by each host. This is not
-massively useful. To set your own choice of column, add this to Foreman's config file
+massively useful. To set your own choice of column, add this to Foreman's plugin config file,
+for example /etc/foreman/plugins/foreman_column_view.yaml
 
 ```yaml
 :column_view:
@@ -35,8 +36,7 @@ massively useful. To set your own choice of column, add this to Foreman's config
 ```
 
 `title` is an arbitrary string which is displayed as the column header. `content` is
-a method call to the `Host` object, using `host.send`. You can also access `Hash` objects
-as well:
+a method call to the `Host` object, using `host.send`. You can also access `Hash` or `Params` objects:
 
 ```yaml
 :column_view:
@@ -48,6 +48,11 @@ as well:
     :title: Uptime
     :after: architecture
     :content: facts_hash['uptime']
+  :color:
+    :title: Color
+    :after: last_report
+    :content: params['favorite_color']
+
 ```
 
 Additional rows can also be added to the Properties table on the host page by setting

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Update Foreman with the new gems:
 # Configuration
 
 By default the plugin will display the Domain associated by each host. This is not
-massively useful. To set your own choice of column, add this to Foreman's plugin config file,
-for example /etc/foreman/plugins/foreman_column_view.yaml
+massively useful. To set your own choice of column, add this to Foreman's plugin config file 
+foreman_column_view.yaml. For package based installs this should be in 
+/etc/foreman/plugins/foreman_column_view.yaml. For source installs the directory may differ.
 
 ```yaml
 :column_view:


### PR DESCRIPTION
I think it's nice if the readme points at the configuration file name/location.

Also had to find out about 'params' option in closed issue #9 from last year. Why not just put it in the readme?