### PR TITLE
Initialize plugin before finisher hook

### DIFF
--- a/lib/foreman_column_view/engine.rb
+++ b/lib/foreman_column_view/engine.rb
@@ -7,7 +7,7 @@ module ForemanColumnView
   #Thus, inhereits from ::Rails::Engine and not from Rails::Engine
   class Engine < ::Rails::Engine
 
-    initializer 'foreman_column_view.register_plugin', :after=> :finisher_hook do |app|
+    initializer 'foreman_column_view.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_column_view do
       end if (Rails.env == "development" or defined? Foreman::Plugin)
     end


### PR DESCRIPTION
Plugins in Foreman have to be initialized now before the finisher hook,
otherwise sprockets messes up the assets loading sequence.

Without this, Foreman will throw `ActionView::Template::Error (couldn't find file 'bootstrap' with type 'application/javascript'`  on every page.  This changed in 1.12 IIRC - but the 'before' hook is backwards compatible.